### PR TITLE
Refactor cache

### DIFF
--- a/core/src/handler.rs
+++ b/core/src/handler.rs
@@ -495,12 +495,12 @@ where
         input = self.source.update(input, source_handle.clone()).await?;
 
         if self.source.should_use_cache(source_handle.clone()).await {
-            Ok(self
-                .persist_to_map(input)
-                .await
-                .into_iter()
-                .map(MaybeArc::Arced)
-                .collect())
+            // Invalidate cache instead of updating it
+            let keys: Vec<CRUD::Pkey> = input.iter().map(|item| item.pkey()).collect();
+            self.invalidate_from_map(&keys).await;
+            
+            // Return items as Owned (not cached)
+            Ok(input.into_iter().map(MaybeArc::Owned).collect())
         } else {
             Ok(input.into_iter().map(MaybeArc::Owned).collect())
         }

--- a/core/src/handler.rs
+++ b/core/src/handler.rs
@@ -495,7 +495,7 @@ where
         input = self.source.update(input, source_handle.clone()).await?;
 
         if self.source.should_use_cache(source_handle.clone()).await {
-            // Invalidate cache instead of updating it
+            // Invalidate cache instead of updating it,only reading from the source should generate new entries in the cache
             let keys: Vec<CRUD::Pkey> = input.iter().map(|item| item.pkey()).collect();
             self.invalidate_from_map(&keys).await;
             
@@ -566,6 +566,7 @@ where
         let mut res_hit = Vec::new();
         let mut res_miss = Vec::new();
 
+        // Zip is guaranteed to be aligned because the order of items in cached_items is same as the corresponding primary keys in keys.
         for (key, cached_item) in keys.iter().zip(cached_items.iter()) {
             match cached_item {
                 Some(item) => res_hit.push(MaybeArc::Arced(item.clone())),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -23,7 +23,7 @@ pub trait Crudable: Clone + Send + Sync + 'static {
 
 #[async_trait]
 pub trait CrudableMap<CRUD: Crudable>: Clone + Send + Sync + 'static {
-    /// Updates the cache but only does that if item's mono is greater. 
+    /// Updates the cache but only does that if item's mono is greater.
     /// This will still return Arc<item> even if it lost to the current inserted entry.
     async fn insert(&self, items: Vec<CRUD>) -> Vec<Arc<CRUD>>;
     async fn invalidate(&self, keys: &[CRUD::Pkey]);
@@ -86,7 +86,7 @@ impl<CRUD: Crudable> CrudableMap<CRUD>
 {
     async fn insert(&self, items: Vec<CRUD>) -> Vec<Arc<CRUD>> {
         let mut results = Vec::with_capacity(items.len());
-        
+
         for item in items {
             let new_item = Arc::new(item);
             let key = new_item.pkey();
@@ -107,7 +107,7 @@ impl<CRUD: Crudable> CrudableMap<CRUD>
 
             results.push(new_item);
         }
-        
+
         results
     }
 
@@ -120,14 +120,15 @@ impl<CRUD: Crudable> CrudableMap<CRUD>
 
     async fn get(&self, keys: &[CRUD::Pkey]) -> Vec<Option<Arc<CRUD>>> {
         let mut results = Vec::with_capacity(keys.len());
-        
+
         for key in keys {
-            let item = moka::future::Cache::<CRUD::Pkey, Arc<arc_swap::ArcSwap<CRUD>>>::get(self, key)
-                .await
-                .map(|x| x.load_full());
+            let item =
+                moka::future::Cache::<CRUD::Pkey, Arc<arc_swap::ArcSwap<CRUD>>>::get(self, key)
+                    .await
+                    .map(|x| x.load_full());
             results.push(item);
         }
-        
+
         results
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -23,8 +23,8 @@ pub trait Crudable: Clone + Send + Sync + 'static {
 
 #[async_trait]
 pub trait CrudableMap<CRUD: Crudable>: Clone + Send + Sync + 'static {
-    /// Updates the cache but only does that if item's mono is greater. This will still return
-    /// Arc<item> even if it lost to the current inserted entry.
+    /// Updates the cache but only does that if item's mono is greater. 
+    /// This will still return Arc<item> even if it lost to the current inserted entry.
     async fn insert(&self, items: Vec<CRUD>) -> Vec<Arc<CRUD>>;
     async fn invalidate(&self, keys: &[CRUD::Pkey]);
     async fn get(&self, keys: &[CRUD::Pkey]) -> Vec<Option<Arc<CRUD>>>;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,10 +25,9 @@ pub trait Crudable: Clone + Send + Sync + 'static {
 pub trait CrudableMap<CRUD: Crudable>: Clone + Send + Sync + 'static {
     /// Updates the cache but only does that if item's mono is greater. This will still return
     /// Arc<item> even if it lost to the current inserted entry.
-    async fn insert(&self, item: CRUD) -> Arc<CRUD>;
-    async fn invalidate(&self, key: &CRUD::Pkey);
-    async fn get(&self, key: &CRUD::Pkey) -> Option<Arc<CRUD>>;
-    async fn contains_key(&self, key: &CRUD::Pkey) -> bool;
+    async fn insert(&self, items: Vec<CRUD>) -> Vec<Arc<CRUD>>;
+    async fn invalidate(&self, keys: &[CRUD::Pkey]);
+    async fn get(&self, keys: &[CRUD::Pkey]) -> Vec<Option<Arc<CRUD>>>;
 }
 
 #[async_trait]
@@ -83,39 +82,50 @@ pub type MokaFutureCrudableMap<CRUD> =
 impl<CRUD: Crudable> CrudableMap<CRUD>
     for moka::future::Cache<CRUD::Pkey, Arc<arc_swap::ArcSwap<CRUD>>>
 {
-    async fn insert(&self, item: CRUD) -> Arc<CRUD> {
-        let new_item = Arc::new(item);
-        let key = new_item.pkey();
+    async fn insert(&self, items: Vec<CRUD>) -> Vec<Arc<CRUD>> {
+        let mut results = Vec::with_capacity(items.len());
+        
+        for item in items {
+            let new_item = Arc::new(item);
+            let key = new_item.pkey();
 
-        // Guarantee that new_item is latest or not included in cache
-        let entry =
-            moka::future::Cache::<CRUD::Pkey, Arc<arc_swap::ArcSwap<CRUD>>>::entry(self, key)
-                .or_insert_with(async { Arc::new(arc_swap::ArcSwap::new(new_item.clone())) })
+            // Guarantee that new_item is latest or not included in cache
+            let entry =
+                moka::future::Cache::<CRUD::Pkey, Arc<arc_swap::ArcSwap<CRUD>>>::entry(self, key)
+                    .or_insert_with(async { Arc::new(arc_swap::ArcSwap::new(new_item.clone())) })
+                    .await;
+
+            entry.value().rcu(|cur| {
+                if cur.mono_field() < new_item.mono_field() {
+                    new_item.clone()
+                } else {
+                    cur.clone()
+                }
+            });
+
+            results.push(new_item);
+        }
+        
+        results
+    }
+
+    async fn invalidate(&self, keys: &[CRUD::Pkey]) {
+        for key in keys {
+            moka::future::Cache::<CRUD::Pkey, Arc<arc_swap::ArcSwap<CRUD>>>::invalidate(self, key)
                 .await;
-
-        entry.value().rcu(|cur| {
-            if cur.mono_field() < new_item.mono_field() {
-                new_item.clone()
-            } else {
-                cur.clone()
-            }
-        });
-
-        new_item
+        }
     }
 
-    async fn invalidate(&self, key: &CRUD::Pkey) {
-        moka::future::Cache::<CRUD::Pkey, Arc<arc_swap::ArcSwap<CRUD>>>::invalidate(self, key)
-            .await;
-    }
-
-    async fn get(&self, key: &CRUD::Pkey) -> Option<Arc<CRUD>> {
-        moka::future::Cache::<CRUD::Pkey, Arc<arc_swap::ArcSwap<CRUD>>>::get(self, key)
-            .await
-            .map(|x| x.load_full())
-    }
-
-    async fn contains_key(&self, key: &CRUD::Pkey) -> bool {
-        moka::future::Cache::<CRUD::Pkey, Arc<arc_swap::ArcSwap<CRUD>>>::contains_key(self, key)
+    async fn get(&self, keys: &[CRUD::Pkey]) -> Vec<Option<Arc<CRUD>>> {
+        let mut results = Vec::with_capacity(keys.len());
+        
+        for key in keys {
+            let item = moka::future::Cache::<CRUD::Pkey, Arc<arc_swap::ArcSwap<CRUD>>>::get(self, key)
+                .await
+                .map(|x| x.load_full());
+            results.push(item);
+        }
+        
+        results
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -27,6 +27,8 @@ pub trait CrudableMap<CRUD: Crudable>: Clone + Send + Sync + 'static {
     /// This will still return Arc<item> even if it lost to the current inserted entry.
     async fn insert(&self, items: Vec<CRUD>) -> Vec<Arc<CRUD>>;
     async fn invalidate(&self, keys: &[CRUD::Pkey]);
+    /// The order of elements found will be the same as the corresponding keys provided as input.
+    /// And if the key didn't exist in the db, corresponding value in the vec will be None.
     async fn get(&self, keys: &[CRUD::Pkey]) -> Vec<Option<Arc<CRUD>>>;
 }
 


### PR DESCRIPTION
Update function interfaces so they use arrays instead of single items
Remove contains_key
On update, if should_use_cache is true, invalidate instead of update